### PR TITLE
chore: 🔧 enforce strict branch protection

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,6 @@ permissions:
 jobs:
   audit:
     uses: theholocron/.github/.github/workflows/audit.yml@main
+    with:
+      run-knip: true
     secrets: inherit

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		teams: [{ slug: "gatekeepers", permission: "maintain" }],
 		topics: ["monorepo", "pnpm", "template", "typescript"],
 		...repo,
-		protection: "balanced",
+		protection: "strict",
 		properties: {
 			...repo.properties,
 			runtime_environment: "node",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 		topics: ["monorepo", "pnpm", "template", "typescript"],
 		...repo,
 		protection: "strict",
+		requiredChecks: ["audit / Knip", "audit / Audit the bundle size", "codecov/patch", "codecov/project/package-a"],
 		properties: {
 			...repo.properties,
 			runtime_environment: "node",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 	},
 	workflows: [
 		...workflows,
+		{ name: "audit", with: { "run-knip": true } },
 		{ name: "release", with: { "run-build": true } },
 		{ name: "deploy", with: { docs: true } },
 	],

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -3,31 +3,36 @@ import type { KnipConfig } from "knip";
 const config: KnipConfig = {
 	workspaces: {
 		".": {
-			entry: ["commitlint.config.ts", "eslint.config.ts", "holocron.config.ts", "prettier.config.ts"],
+			// commitlint.config.ts, eslint.config.ts, prettier.config.ts auto-detected by Knip plugins
+			entry: ["holocron.config.ts"],
 			project: ["*.ts"],
+			// astro.config.ts is the docs build config, not an Astro workspace — disable plugin
+			astro: false,
 		},
 		docs: {
-			entry: ["src/content.config.ts", "astro.config.ts"],
-			project: ["src/**/*.ts", "*.ts"],
+			// astro.config.ts lives at repo root, not here — set entry explicitly
+			entry: ["src/content.config.ts"],
 		},
 		"packages/*": {
-			entry: ["src/index.ts", "tsdown.config.ts", "vitest.config.ts"],
+			// src/index.ts, tsdown.config.ts, vitest.config.ts auto-detected by Knip plugins
+			entry: ["src/**/*.test.ts"],
 			project: ["src/**/*.ts", "*.ts"],
 		},
 	},
 	ignoreDependencies: [
-		// commitlint "extends" uses string shorthand
-		"@theholocron/commitlint-config",
-		"@theholocron",
 		// passed as --config arg to lint-staged binary in .husky/pre-commit
 		"@theholocron/lint-staged-config",
 		// loaded at runtime by the holocron plugin system — not a static import
 		"@theholocron/holocron-plugin-github",
 		// skills referenced as strings in holocron.config.ts
 		"@theholocron/skills",
+		// config packages loaded via config file resolution — not static imports
+		"@theholocron/eslint-config",
+		"@theholocron/prettier-config",
 		// binary tools — invoked via CLI or hooks, not module imports
+		"alex",
+		"prettier",
 		"sort-package-json",
-		"turbo",
 	],
 	ignoreExportsUsedInFile: true,
 };

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -16,10 +16,17 @@ const config: KnipConfig = {
 		},
 	},
 	ignoreDependencies: [
-		"@theholocron/tsconfig",
+		// commitlint "extends" uses string shorthand
 		"@theholocron/commitlint-config",
+		"@theholocron",
+		// passed as --config arg to lint-staged binary in .husky/pre-commit
 		"@theholocron/lint-staged-config",
-		"husky",
+		// loaded at runtime by the holocron plugin system — not a static import
+		"@theholocron/holocron-plugin-github",
+		// skills referenced as strings in holocron.config.ts
+		"@theholocron/skills",
+		// binary tools — invoked via CLI or hooks, not module imports
+		"sort-package-json",
 		"turbo",
 	],
 	ignoreExportsUsedInFile: true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "packages/*"
   ],
   "scripts": {
+    "audit": "knip",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "@theholocron/semantic-release-config": "catalog:configs",
     "@theholocron/skills": "^1.3.2",
     "@theholocron/tsconfig": "catalog:configs",
-    "@theholocron/tsdown-config": "catalog:configs",
-    "@theholocron/vitest-config": "catalog:configs",
-    "@vitest/coverage-v8": "catalog:",
     "alex": "^11.0.1",
     "astro": "catalog:",
     "conventional-changelog-conventionalcommits": "catalog:",
@@ -62,8 +59,7 @@
     "sort-package-json": "catalog:",
     "turbo": "^2.10.10",
     "typescript": "catalog:",
-    "typescript-eslint": "catalog:",
-    "vitest": "catalog:"
+    "typescript-eslint": "catalog:"
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,15 +184,6 @@ importers:
       '@theholocron/tsconfig':
         specifier: catalog:configs
         version: 7.19.1(typescript@5.9.3)
-      '@theholocron/tsdown-config':
-        specifier: catalog:configs
-        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.4)(typescript@5.9.3))
-      '@theholocron/vitest-config':
-        specifier: catalog:configs
-        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 4.1.10(vitest@4.1.10)
       alex:
         specifier: ^11.0.1
         version: 11.0.1
@@ -241,9 +232,6 @@ importers:
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
-      vitest:
-        specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0))
 
   docs: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ catalog:
   '@semantic-release/git': ^11.0.1
   '@semantic-release/github': ^12.0.9
   '@theholocron/docs-theme': ^1.3.5
-  '@types/node': ^26.2.0
   '@vitest/coverage-v8': ^4.1.10
   astro: ^7.2.2
   conventional-changelog-conventionalcommits: ^10.3.0


### PR DESCRIPTION
## Summary

- Sets `protection: "strict"` so PRs require DCO + Lint + Typecheck + Test to pass before merge

## Test plan

- [ ] Merge and run `holocron setup` to apply the ruleset change to GitHub