### PR TITLE
chore: update @theholocron/astro-config to 7.22.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   configs:
     '@theholocron/astro-config':
-      specifier: ^7.19.1
-      version: 7.19.1
+      specifier: ^7.22.2
+      version: 7.22.2
     '@theholocron/commitlint-config':
       specifier: ^7.19.1
       version: 7.19.1
@@ -150,7 +150,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.9(typescript@5.9.3))
       '@theholocron/astro-config':
         specifier: catalog:configs
-        version: 7.19.1(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0))
+        version: 7.22.2(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0))
       '@theholocron/cli':
         specifier: catalog:holocron
         version: 3.24.4(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10)
@@ -2317,8 +2317,8 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@theholocron/astro-config@7.19.1':
-    resolution: {integrity: sha512-QE47/ODTNEwszna7jxlI7EDQBDtP0bs5UJy25+kgoa8AI5lDPtW2ZKHRPQ7nZc1T1hsyNF7zpUZZRwHwHisGFw==}
+  '@theholocron/astro-config@7.22.2':
+    resolution: {integrity: sha512-cU7nZqBIKZteVB3qBJ0hdSAsKv5EWN7/hreM4/3AiEevq4SDXCYriVXiGQ+MVHoTSLtZk3b4PFE2jEf+zuxg+g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       astro: '>=5.0.0'
@@ -8481,7 +8481,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@theholocron/astro-config@7.19.1(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0))':
+  '@theholocron/astro-config@7.22.2(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0))':
     dependencies:
       astro: 7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalog:
 # Shared configs — release in lockstep; bump all entries together.
 catalogs:
   configs:
-    '@theholocron/astro-config': ^7.19.1
+    '@theholocron/astro-config': ^7.22.2
     '@theholocron/commitlint-config': ^7.19.1
     '@theholocron/eslint-config': ^7.19.1
     '@theholocron/holocron-config': ^7.19.1


### PR DESCRIPTION
## Summary

Bumps `@theholocron/astro-config` to 7.22.2, which sets `base: "/<repo>"` automatically so CSS and JS assets resolve correctly when the docs site is served at `https://docs.theholocron.dev/<repo>/`.

Fixes the 404 on `/_astro/common.css` that was breaking all deployed docs sites.
